### PR TITLE
Raw Game Create Form (Roadmap #58)

### DIFF
--- a/play/apps/play/templates/create.html
+++ b/play/apps/play/templates/create.html
@@ -18,16 +18,16 @@
 
             <div class="card-body">
 
-                <div class="form-row">
+                <div class="form-row" id="BoardOptions">
 
                     <label class="col-form-label col-lg-1 pl-3" for="Width">Width:</label>
-                    <input type="number" class="form-control col-lg-3" min="0" id="Width" value="20">
+                    <input type="number" class="form-control col-lg-3" min="0" name="Width" id="Width" value="20">
 
                     <label class="col-form-label col-lg-1 pl-3" for="Height">Height:</label>
-                    <input type="number" class="form-control col-lg-3" min="0" id="Height" value="20">
+                    <input type="number" class="form-control col-lg-3" min="0" name="Height" id="Height" value="20">
 
                     <label class="col-form-label col-lg-1 pl-3" for="Food">Food:</label>
-                    <input type="number" class="form-control col-lg-3" min="0" id="Food" value="10">
+                    <input type="number" class="form-control col-lg-3" min="0" name="Food" id="Food" value="10">
 
                 </div>
 
@@ -45,19 +45,27 @@
 
                 {% for i in 10|times %}
 
-                <div class="form-row my-1">
+                <div class="form-row my-1 snake-row">
 
-                    <label class="col-form-label col-lg-2 col-form-label-sm pl-3" for="SnakeURL{{forloop.counter}}">
+                    <label class="col-form-label col-lg-2 col-form-label-sm pl-3"
+                           for="SnakeURL{{forloop.counter}}">
                         URL:
                     </label>
 
-                    <input type="text" class="form-control form-control-sm col-lg-4" id="SnakeURL{{forloop.counter}}">
+                    <input type="text"
+                           class="form-control form-control-sm col-lg-4"
+                           id="SnakeURL{{forloop.counter}}"
+                           name="Snake.URL"/>
 
-                    <label class="col-form-label col-lg-2 col-form-label-sm pl-3" for="SnakeName{{forloop.counter}}">
+                    <label class="col-form-label col-lg-2 col-form-label-sm pl-3"
+                           for="SnakeName{{forloop.counter}}">
                         Name:
                     </label>
 
-                    <input type="text" class="form-control col-lg-4 form-control-sm" id="SnakeName{{forloop.counter}}">
+                    <input type="text"
+                           class="form-control col-lg-4 form-control-sm"
+                           id="SnakeName{{forloop.counter}}"
+                           name="Snake.Name"/>
 
                 </div>
 
@@ -76,4 +84,56 @@
     </form>
 
 </div>
+
+<script>
+    /**
+     * Serializes HTML form data to JSON.
+     * Based on Stack Overflow example here:
+     *   https://stackoverflow.com/questions/35936553/jquery-convert-html-form-to-json-in-a-correct-format
+     */
+    function serializeFormJSON(form) {
+        let o = {};
+        let a = form.serializeArray();
+
+        $.each(a, function() {
+            // If an item was already defined, consider it a list.
+            if (o[this.name] !== undefined) {
+                if (!o[this.name].push) {
+                    o[this.name] = [o[this.name]];
+                }
+
+                o[this.name].push(this.value || '');
+            }
+            else {
+                o[this.name] = this.value || '';
+            }
+        });
+
+        return o;
+    }
+
+    $("#CreateGameForm").submit((e) => {
+        e.preventDefault();
+
+        // Serialize board options as JSON
+        let gameOptions = serializeFormJSON($("#BoardOptions").children(":input"));
+
+        // Serialize snake options
+        let snakes = [];
+        $("div.snake-row").each((ind, ele) => {
+
+            let snake = {
+                "Name": $(ele).children("input[name='Snake.Name']").val(),
+                "URL":  $(ele).children("input[name='Snake.URL']").val()
+            };
+            if (snake.Name && snake.URL)
+                snakes.push(snake);
+
+        });
+        gameOptions.Snakes = snakes;
+
+        console.log(gameOptions);
+    });
+
+</script>
 {% endblock %}

--- a/play/apps/play/templates/create.html
+++ b/play/apps/play/templates/create.html
@@ -1,0 +1,79 @@
+{% extends 'base.html' %}
+{% load play_extras %}
+
+{% block content %}
+<div class="container">
+
+    <h2 class="py-3">
+        Create a Game
+    </h2>
+
+    <form class="form-horizontal" id="CreateGameForm">
+
+        <div class="form-group card">
+
+            <div class="card-header">
+                Game Options
+            </div>
+
+            <div class="card-body">
+
+                <div class="form-row">
+
+                    <label class="col-form-label col-lg-1 pl-3" for="Width">Width:</label>
+                    <input type="number" class="form-control col-lg-3" min="0" id="Width" value="20">
+
+                    <label class="col-form-label col-lg-1 pl-3" for="Height">Height:</label>
+                    <input type="number" class="form-control col-lg-3" min="0" id="Height" value="20">
+
+                    <label class="col-form-label col-lg-1 pl-3" for="Food">Food:</label>
+                    <input type="number" class="form-control col-lg-3" min="0" id="Food" value="10">
+
+                </div>
+
+            </div>
+
+        </div>
+
+        <div class="form-group card">
+
+            <div class="card-header">
+                Snakes
+            </div>
+
+            <div class="card-body">
+
+                {% for i in 10|times %}
+
+                <div class="form-row my-1">
+
+                    <label class="col-form-label col-lg-2 col-form-label-sm pl-3" for="SnakeURL{{forloop.counter}}">
+                        URL:
+                    </label>
+
+                    <input type="text" class="form-control form-control-sm col-lg-4" id="SnakeURL{{forloop.counter}}">
+
+                    <label class="col-form-label col-lg-2 col-form-label-sm pl-3" for="SnakeName{{forloop.counter}}">
+                        Name:
+                    </label>
+
+                    <input type="text" class="form-control col-lg-4 form-control-sm" id="SnakeName{{forloop.counter}}">
+
+                </div>
+
+                {% endfor %}
+
+            </div>
+
+        </div>
+
+        <div class="form-group">
+            <input class="btn btn-primary" type="submit" value="Create Game">
+            <input class="btn btn-link" type="button" value="Show" disabled>
+        </div>
+
+
+    </form>
+
+</div>
+{% endblock %}

--- a/play/apps/play/templatetags/play_extras.py
+++ b/play/apps/play/templatetags/play_extras.py
@@ -1,0 +1,8 @@
+from django import template
+
+register = template.Library()
+
+
+@register.filter(name='times')
+def times(number):
+    return range(1, number + 1)

--- a/play/apps/play/views/create.py
+++ b/play/apps/play/views/create.py
@@ -1,0 +1,5 @@
+from django.shortcuts import render
+
+
+def create(request):
+    return render(request, 'create.html')

--- a/play/urls.py
+++ b/play/urls.py
@@ -17,10 +17,12 @@ from django.conf.urls import url, include
 from django.contrib import admin
 from django.contrib.auth import views as auth_views
 from apps.play.views.home import home
+from apps.play.views.create import create
 
 
 urlpatterns = [
     url(r'^$', home, name='home'),
+    url(r'^create/$', create, name='create'),
     url(r'^login/$', auth_views.login, name='login'),
     url(r'^logout/$', auth_views.logout, name='logout'),
     url(r'^oauth/', include('social_django.urls', namespace='social')),  # <--


### PR DESCRIPTION
Raw HTML form for sending create game requests to the engine. I implemented this thinking that requests to the engine could be sent directly from the browser, but it might be worthwhile to do this through the play server.

The form can be accessed at `http://localhost:8000/create`.

Currently implemented:
* Raw HTML create form (no logic for sending)
* Client-side Javascript for serializing the form into the correct format for a `/create` request to the engine server