### PR TITLE
Adds a clean way to add more snakes on demand

### DIFF
--- a/play/apps/authentication/urls.py
+++ b/play/apps/authentication/urls.py
@@ -4,7 +4,7 @@ from apps.authentication import views
 
 urlpatterns = [
     url(r'^$', views.index, name='home'),
-    url(r'^login/$', auth_views.login, name='login',),
-    url(r'^logout/$', auth_views.logout, name='logout'),
+    url(r'^login/$', auth_views.login, name='login'),
+    url(r'^logout/$', views.logout_view, name='logout'),
     url(r'^oauth/', include('social_django.urls', namespace='social')),
 ]

--- a/play/apps/authentication/views.py
+++ b/play/apps/authentication/views.py
@@ -1,7 +1,16 @@
-from django.shortcuts import redirect
+from django.contrib.auth import logout
 from django.contrib.auth.decorators import login_required
+from django.shortcuts import redirect
 
 
 @login_required
 def index(request):
     return redirect('/team')
+
+
+@login_required
+def logout_view(request):
+    logout(request)
+    return redirect('/login')
+
+

--- a/play/apps/game/forms.py
+++ b/play/apps/game/forms.py
@@ -1,58 +1,106 @@
+import re
+
 from django import forms
+from django.forms import ValidationError
+
 from apps.game import engine
+from apps.game.models import Game
+from apps.snake.models import Snake
+from apps.utils.url import is_valid_url
+
+
+SNAKE_FORMSET_INDEX_REGEX = re.compile(r'^snake\-(\d+)')
+
+
+def get_snakes_from_request(request_data):
+    """
+    `request_data` contains formset form data in a structure like
+    ```
+    {
+        ...
+        'snake-0-name: ...,
+        'snake-0-url: ...,
+        'snake-1-name: ...,
+        'snake-1-url: ...,
+        ...
+    }
+    ```
+    but also contains other `request.POST` data so we only focus
+    on keys that we're interested.
+    """
+    snakes = []
+    for k,v in request_data.items():
+        index = re.findall(SNAKE_FORMSET_INDEX_REGEX, k)
+        if index:
+            i = int(index[0])
+            try:
+                snakes[i]
+            except IndexError:
+                # The object at the current index doesn't exist
+                # in the list yet, so add one
+                snakes.append({})
+            if 'name' in k and v:
+                snakes[i]['name'] = request_data.get(f'snake-{i}-name')
+            if 'url' in k and v:
+                snakes[i]['url'] = request_data.get(f'snake-{i}-url')
+    return snakes
+
+
+class SnakeForm(forms.Form):
+    """
+    SnakeForm initializes a row containing snake name and url
+    """
+
+    name = forms.CharField(
+        max_length=100,
+        label=f'Snake Name',
+        required=True,
+        widget=forms.TextInput()
+    )
+
+    url = forms.CharField(
+        max_length=100,
+        label=f'Snake Url',
+        required=True,
+        widget=forms.URLInput()
+    )
 
 
 class GameForm(forms.Form):
     """
-    GameForm initializes a game and posts this to the backend to start the game.
-    this should be massively improved as the HTML is pretty ugly that it
-    produces.
+    GameForm initializes a game and posts this to the engine to start the game.
     """
-    DEFAULT_HEIGHT = 20
-    DEFAULT_WIDTH = 20
-    DEFAULT_FOOD = 5
-    MAX_SNAKES = 10
+    # MAX_SNAKES = 10
 
-    width = forms.IntegerField(initial=DEFAULT_WIDTH)
-    height = forms.IntegerField(initial=DEFAULT_HEIGHT)
-    food = forms.IntegerField(initial=DEFAULT_FOOD)
+    width = forms.IntegerField(initial=20, required=True)
+    height = forms.IntegerField(initial=20, required=True)
+    food = forms.IntegerField(initial=5, required=True)
 
     def __init__(self, *args, **kwargs):
+        self.snakes = kwargs.pop('snakes', None)
         super().__init__(*args, **kwargs)
-        for i in range(1, self.MAX_SNAKES + 1):
-            self.fields[f'snake_name_{i}'] = forms.CharField(
-                max_length=100,
-                label=f'Snake {i} Name',
-                required=False,
-                widget=forms.TextInput()
-            )
-
-            self.fields[f'snake_url_{i}'] = forms.CharField(
-                max_length=100,
-                label=f'Snake {i} Url',
-                required=False,
-                widget=forms.URLInput()
-            )
-
-            # Note: This "groups" is used to create the form on the front end
-            self.fields[f'snake_name_{i}'].group = 'snake'
-            self.fields[f'snake_url_{i}'].group = 'snake'
 
     def clean(self):
         cleaned_data = super().clean()
-        snakes = []
-        for key in cleaned_data.keys():
-            if key.startswith('snake_name_') and cleaned_data[key]:
-                idx = int(key.split('_')[-1])
-                snakes.append({
-                    'name': self.cleaned_data[key],
-                    'url': self.cleaned_data[f'snake_url_{idx}']
-                })
+
+        if not self.snakes:
+            raise ValidationError('Must add at least 1 snake to start a game')
+
+        for snake in self.snakes:
+            if not snake.get('name'):
+                raise ValidationError('Snake requires a name')
+
+            if not snake.get('url'):
+                raise ValidationError('Snake requires a URL')
+
+            if not is_valid_url(snake['url']):
+                raise ValidationError('Snake requires a valid URL')
+
         return {
-            'width': cleaned_data['width'],
-            'height': cleaned_data['height'],
-            'food': cleaned_data['food'],
-            'snakes': snakes,
+            'width': self.cleaned_data['width'],
+            'height': self.cleaned_data['height'],
+            'food': self.cleaned_data['food'],
+            'snakes': self.snakes,
         }
 
     def submit(self):

--- a/play/apps/game/templates/games/new.html
+++ b/play/apps/game/templates/games/new.html
@@ -1,16 +1,34 @@
 {% extends 'base.html' %}
+
 {% block content %}
 <main class="container-fluid">
   <h1 class="text-center">New Game</h1>
 
   <div class="form-group card">
     <div class="card-body">
-      <form method="post" novalidate action="/games/">
+      <form method="post" novalidate action="/games/new/">
         {% csrf_token %}
-        {% include '_new_snake_form.html' with form=form %}
-        <button type="submit" class="btn btn-primary">Submit</button>
+        {% include '_new_snake_form.html' with game_form=game_form snake_formset=snake_formset %}
+        <hr />
+        <div class="form-group">
+          <button type="submit" class="btn btn-primary btn-block">
+            Create Game
+          </button>
+        </div>
       </form>
     </div>
   </div>
 </main>
+{% endblock %}
+
+{% block js_dom_ready %}
+$(".js-snake-formset").formset({
+  prefix: 'snake',
+  addText: 'Add Snake',
+  deleteText: 'Remove',
+  addCssClass: 'btn btn-secondary btn-small',
+  deleteCssClass: 'btn btn-danger btn-small',
+  addContainerClass: 'js-snake-add',
+  deleteContainerClass: 'js-snake-remove',
+})
 {% endblock %}

--- a/play/apps/game/urls.py
+++ b/play/apps/game/urls.py
@@ -5,10 +5,10 @@ from util.routing import method_dispatch
 urlpatterns = [
     url(r'^games/$', method_dispatch(
         GET=views.games.index,
-        POST=views.games.create,
     ), name='games'),
     url(r'^games/new/$', method_dispatch(
         GET=views.games.new,
+        POST=views.games.new,
     ), name='games_new'),
     url(r'^games/(?P<id>.+)/$', method_dispatch(
         GET=views.games.show,

--- a/play/apps/game/views/games.py
+++ b/play/apps/game/views/games.py
@@ -1,8 +1,10 @@
+from django.forms import formset_factory
 from django.shortcuts import render, redirect
-from django.conf import settings
-from django.utils.http import urlquote
 from django.contrib.auth.decorators import login_required
-from apps.game.forms import GameForm
+
+from apps.game.forms import GameForm, SnakeForm, get_snakes_from_request
+from apps.snake.models import get_user_snakes
+from apps.utils.helpers import generate_game_url
 
 
 @login_required
@@ -12,25 +14,40 @@ def index(request):
 
 @login_required
 def new(request):
+    if request.method == 'POST':
+        # GameForm doesn't contain snake data so we have to get it off the request
+        game_snakes = get_snakes_from_request(request.POST.dict())
+        game_form = GameForm(request.POST, snakes=game_snakes)
+        if game_form.is_valid():
+            game_id = game_form.submit()
+            return redirect(f'/games/{game_id}')
+        else:
+            status = 400
+    else:
+        status = 200
+        game_form = GameForm()
+
+    snakes = get_user_snakes(request.user)
+    SnakeFormSet = formset_factory(
+        SnakeForm,
+        extra=0,
+        min_num=1,
+        max_num=10,
+        validate_min=True,
+        validate_max=True,
+    )
+    snake_formset = SnakeFormSet(prefix='snake')
+
     return render(request, 'games/new.html', {
-        'form': GameForm(),
-    })
+        'game_form': game_form,
+        'snake_formset': snake_formset,
+        'snakes': snakes,
+    }, status=status)
 
 
 @login_required
 def show(request, id):
     return render(request, 'games/show.html', {
         'id': id,
-        'url': f'{settings.BOARD_URL}/?engine={urlquote(settings.ENGINE_URL)}&game={id}'
+        'url': generate_game_url(id)
     })
-
-
-@login_required
-def create(request):
-    form = GameForm(request.POST)
-    if form.is_valid():
-        game_id = form.submit()
-        return redirect(f'/games/{game_id}')
-    return render(request, 'games/new.html', {
-        'form': form,
-    }, status=400)

--- a/play/apps/snake/models.py
+++ b/play/apps/snake/models.py
@@ -3,6 +3,13 @@ from django.db import models
 from util.fields import ShortUUIDField
 from apps.authentication.models import User
 
+def get_user_snakes(user):
+    return [
+        user_snake.snake for user_snake in
+        UserSnake.objects.filter(user_id=user.id).
+        prefetch_related('snake')
+    ]
+
 
 class Snake(models.Model):
     id = ShortUUIDField(prefix="snk", max_length=128, primary_key=True)

--- a/play/apps/snake/views/snakes.py
+++ b/play/apps/snake/views/snakes.py
@@ -1,17 +1,14 @@
 from django.shortcuts import render, redirect
 from django.contrib.auth.decorators import login_required
 from django.db import transaction
-from apps.snake.models import UserSnake
+
+from apps.snake.models import UserSnake, get_user_snakes
 from apps.snake.forms import SnakeForm
 
 
 @login_required
 def index(request):
-    snakes = [
-        user_snake.snake for user_snake in
-        UserSnake.objects.filter(user_id=request.user.id).
-        prefetch_related('snake')
-    ]
+    snakes = get_user_snakes(request.user)
     return render(request, 'snakes/index.html', {
         'snakes': snakes,
         'user': request.user,

--- a/play/apps/utils/helpers.py
+++ b/play/apps/utils/helpers.py
@@ -1,0 +1,5 @@
+from django.conf import settings
+from django.utils.http import urlquote
+
+def generate_game_url(id):
+    return f'{settings.BOARD_URL}/?engine={urlquote(settings.ENGINE_URL)}&game={id}'

--- a/play/apps/utils/url.py
+++ b/play/apps/utils/url.py
@@ -1,0 +1,10 @@
+from django.core.validators import URLValidator
+from django.core.exceptions import ValidationError
+
+def is_valid_url(url):
+    validate = URLValidator()
+    try:
+        validate(url)
+        return True
+    except ValidationError:
+        return False

--- a/play/settings/base.py
+++ b/play/settings/base.py
@@ -62,7 +62,7 @@ if is_production_env():
 # Application definition
 
 INSTALLED_APPS = [
-    'django.contrib.admin',
+    # 'django.contrib.admin',
     'django.contrib.auth',
     'django.contrib.contenttypes',
     'django.contrib.sessions',

--- a/play/static/jquery.formset.js
+++ b/play/static/jquery.formset.js
@@ -1,0 +1,261 @@
+/**
+ * jQuery Formset 1.4-pre
+ * COPIED FROM https://github.com/nferrari/django-dynamic-formset DUE TO UPDATES
+ * @author Stanislaus Madueke (stan DOT madueke AT gmail DOT com)
+ * @requires jQuery 1.2.6 or later
+ *
+ * Copyright (c) 2009, Stanislaus Madueke
+ * All rights reserved.
+ *
+ * Licensed under the New BSD License
+ * See: http://www.opensource.org/licenses/bsd-license.php
+ */
+(function($) {
+  $.fn.formset = function(opts) {
+    let options = $.extend({}, $.fn.formset.defaults, opts),
+      flatExtraClasses = options.extraClasses.join(' '),
+      totalForms = $('#id_' + options.prefix + '-TOTAL_FORMS'),
+      maxForms = $('#id_' + options.prefix + '-MAX_NUM_FORMS'),
+      minForms = $('#id_' + options.prefix + '-MIN_NUM_FORMS'),
+      childElementSelector = 'input,select,textarea,label,div',
+      $$ = $(this),
+
+      applyExtraClasses = function(row, ndx) {
+        if (options.extraClasses) {
+          row.removeClass(flatExtraClasses)
+          row.addClass(options.extraClasses[ndx % options.extraClasses.length])
+        }
+      },
+
+      updateElementIndex = function(elem, prefix, ndx) {
+        let idRegex = new RegExp(prefix + '-(\\d+|__prefix__)-'),
+          replacement = prefix + '-' + ndx + '-'
+        if (elem.attr("for")) elem.attr("for", elem.attr("for").replace(idRegex, replacement))
+        if (elem.attr('id')) elem.attr('id', elem.attr('id').replace(idRegex, replacement))
+        if (elem.attr('name')) elem.attr('name', elem.attr('name').replace(idRegex, replacement))
+      },
+
+      hasChildElements = function(row) {
+        return row.find(childElementSelector).length > 0
+      },
+
+      showAddButton = function() {
+        return maxForms.length === 0 || // For Django versions pre 1.2
+          (maxForms.val() === '' || (maxForms.val() - totalForms.val() > 0))
+      },
+
+      /**
+       * Indicates whether delete link(s) can be displayed - when total forms > min forms
+       */
+      showDeleteLinks = function() {
+        return minForms.length === 0 || // For Django versions pre 1.7
+          (minForms.val() === '' || (totalForms.val() - minForms.val() > 0))
+      },
+
+      insertDeleteLink = function(row) {
+        let delCssSelector = $.trim(options.deleteCssClass).replace(/\s+/g, '.'),
+          addCssSelector = $.trim(options.addCssClass).replace(/\s+/g, '.')
+
+        let delButton = row.find('button.' + delCssSelector)
+        if (!delButton.length) {
+          // Didn't find a delete button in the row already. Let's add one.
+          let delButtonHTML = '<button class="' + options.deleteCssClass + '" type="button">' + options.deleteText + '</button>'
+          if (options.deleteContainerClass) {
+            // If we have a specific container for the remove button,
+            // place it as the last child of that container:
+            row.find('[class*="' + options.deleteContainerClass + '"]').append(delButtonHTML)
+          } else if (row.is('TR')) {
+            // If the forms are laid out in table rows, insert
+            // the remove button into the last table cell:
+            row.children(':last').append(delButtonHTML)
+          } else if (row.is('UL') || row.is('OL')) {
+            // If they're laid out as an ordered/unordered list,
+            // insert an <li> after the last list item:
+            row.append('<li>' + delButtonHTML + '</li>')
+          } else {
+            // Otherwise, just insert the remove button as the
+            // last child element of the form's container:
+            row.append(delButtonHTML)
+          }
+
+          // And now we can use it!
+          delButton = row.find('button.' + delCssSelector)
+        }
+
+
+        // Check if we're under the minimum number of forms - not to display delete link at rendering
+        if (!showDeleteLinks()) {
+          delButton.hide()
+        }
+
+        delButton.click(function() {
+          let row = $(this).parents('.' + options.formCssClass),
+            del = row.find('input:hidden[id $= "-DELETE"]'),
+            addButton = row.siblings("button." + addCssSelector + ', .' + options.formCssClass + '-add'),
+            forms
+          if (del.length) {
+            // We're dealing with an inline formset.
+            // Rather than remove this form from the DOM, we'll mark it as deleted
+            // and hide it, then let Django handle the deleting:
+            del.val('on')
+            row.hide()
+            forms = $('.' + options.formCssClass).not(':hidden')
+          } else {
+            row.remove()
+            // Update the TOTAL_FORMS count:
+            forms = $('.' + options.formCssClass).not('.formset-custom-template')
+            totalForms.val(forms.length)
+          }
+          for (let i = 0, formCount = forms.length; i < formCount; i++) {
+            // Apply `extraClasses` to form rows so they're nicely alternating:
+            applyExtraClasses(forms.eq(i), i)
+            if (!del.length) {
+              // Also update names and IDs for all child controls (if this isn't
+              // a delete-able inline formset) so they remain in sequence:
+              forms.eq(i).find(childElementSelector).each(function() {
+                updateElementIndex($(this), options.prefix, i)
+              })
+            }
+          }
+          // Check if we've reached the minimum number of forms - hide all delete link(s)
+          if (!showDeleteLinks()) {
+            $('button.' + delCssSelector).each(function() {
+              $(this).hide()
+            })
+          }
+          // Check if we need to show the add button:
+          if (addButton.is(':hidden') && showAddButton()) addButton.show()
+          // If a post-delete callback was provided, call it with the deleted form:
+          if (options.removed) options.removed(row)
+          return false
+        })
+      }
+
+    $$.each(function(i) {
+      let row = $(this),
+        del = row.find('input:checkbox[id $= "-DELETE"]')
+      if (del.length) {
+        // If you specify "can_delete = True" when creating an inline formset,
+        // Django adds a checkbox to each form in the formset.
+        // Replace the default checkbox with a hidden field:
+        if (del.is(':checked')) {
+          // If an inline formset containing deleted forms fails validation, make sure
+          // we keep the forms hidden (thanks for the bug report and suggested fix Mike)
+          del.before('<input type="hidden" name="' + del.attr('name') + '" id="' + del.attr('id') + '" value="on" />')
+          row.hide()
+        } else {
+          del.before('<input type="hidden" name="' + del.attr('name') + '" id="' + del.attr('id') + '" />')
+        }
+        // Hide any labels associated with the DELETE checkbox:
+        $('label[for="' + del.attr('id') + '"]').hide()
+        del.remove()
+      }
+      if (hasChildElements(row)) {
+        row.addClass(options.formCssClass)
+        if (row.is(':visible')) {
+          insertDeleteLink(row)
+          applyExtraClasses(row, i)
+        }
+      }
+    })
+
+    if ($$.length) {
+      let hideAddButton = !showAddButton(),
+        addButton, template
+      if (options.formTemplate) {
+        // If a form template was specified, we'll clone it to generate new form instances:
+        template = (options.formTemplate instanceof $) ? options.formTemplate : $(options.formTemplate)
+        template.removeAttr('id').addClass(options.formCssClass + ' formset-custom-template')
+        template.find(childElementSelector).each(function() {
+          updateElementIndex($(this), options.prefix, '__prefix__')
+        })
+        insertDeleteLink(template)
+        template.hide()
+      } else {
+        // Otherwise, use the last form in the formset this works much better if you've got
+        // extra (>= 1) forms (thnaks to justhamade for pointing this out):
+        template = $('.' + options.formCssClass + ':last').clone(true).removeAttr('id')
+        template.find('input:hidden[id $= "-DELETE"]').remove()
+        // Clear all cloned fields, except those the user wants to keep (thanks to brunogola for the suggestion):
+        template.find(childElementSelector).not(options.keepFieldValues).each(function() {
+          let elem = $(this)
+          // If this is a checkbox or radiobutton, uncheck it.
+          // This fixes Issue 1, reported by Wilson.Andrew.J:
+          if (elem.is('input:checkbox') || elem.is('input:radio')) {
+            elem.attr('checked', false)
+          } else {
+            elem.val('')
+          }
+        })
+      }
+      // FIXME: Perhaps using $.data would be a better idea?
+      options.formTemplate = template
+
+      let addButtonHTML = '<button class="' + options.addCssClass + '" type="button">' + options.addText + '</button>'
+      if (options.addContainerClass) {
+        // If we have a specific container for the "add" button,
+        // place it as the last child of that container:
+        let addContainer = $('[class*="' + options.addContainerClass + '"')
+        addContainer.append(addButtonHTML)
+        addButton = addContainer.find('[class="' + options.addCssClass + '"]')
+      } else if ($$.is('TR')) {
+        // If forms are laid out as table rows, insert the
+        // "add" button in a new table row:
+        let numCols = $$.eq(0).children().length, // This is a bit of an assumption :|
+          buttonRow = $('<tr><td colspan="' + numCols + '">' + addButtonHTML + '</tr>').addClass(options.formCssClass + '-add')
+        $$.parent().append(buttonRow)
+        addButton = buttonRow.find('button')
+      } else {
+        // Otherwise, insert it immediately after the last form:
+        $$.filter(':last').after(addButtonHTML)
+        addButton = $$.filter(':last').next()
+      }
+
+      if (hideAddButton) addButton.hide()
+
+      addButton.click(function() {
+        let formCount = parseInt(totalForms.val()),
+          row = options.formTemplate.clone(true).removeClass('formset-custom-template'),
+          lastRow = $('.' + options.formCssClass).filter(':last'),
+          buttonRow = $($(this).parents('tr.' + options.formCssClass + '-add').get(0) || this),
+          delCssSelector = $.trim(options.deleteCssClass).replace(/\s+/g, '.')
+        applyExtraClasses(row, formCount)
+        row.insertAfter(lastRow).show()
+        row.find(childElementSelector).each(function() {
+          updateElementIndex($(this), options.prefix, formCount)
+        })
+        totalForms.val(formCount + 1)
+        // Check if we're above the minimum allowed number of forms -> show all delete link(s)
+        if (showDeleteLinks()) {
+          $('button.' + delCssSelector).each(function() {
+            $(this).show()
+          })
+        }
+        // Check if we've exceeded the maximum allowed number of forms:
+        if (!showAddButton()) buttonRow.hide()
+        // If a post-add callback was supplied, call it with the added form:
+        if (options.added) options.added(row)
+        return false
+      })
+    }
+
+    return $$
+  }
+
+  /* Setup plugin defaults */
+  $.fn.formset.defaults = {
+    prefix: 'form', // The form prefix for your django formset
+    formTemplate: null, // The jQuery selection cloned to generate new form instances
+    addText: 'add another', // Text for the add link
+    deleteText: 'remove', // Text for the delete link
+    addContainerClass: null, // Container CSS class for the add link
+    deleteContainerClass: null, // Container CSS class for the delete link
+    addCssClass: 'add-row', // CSS class applied to the add link
+    deleteCssClass: 'delete-row', // CSS class applied to the delete link
+    formCssClass: 'dynamic-form', // CSS class applied to each form in a formset
+    extraClasses: [], // Additional CSS classes, which will be applied to each form in turn
+    keepFieldValues: '', // jQuery selector for fields whose values should be kept when the form is cloned
+    added: null, // Function called each time a new form is added
+    removed: null // Function called each time a form is deleted
+  }
+})(jQuery)

--- a/play/templates/_new_snake_form.html
+++ b/play/templates/_new_snake_form.html
@@ -1,78 +1,104 @@
 {% load widget_tweaks %}
 
-{% for hidden_field in form.hidden_fields %}
+{% for hidden_field in game_form.hidden_fields %}
   {{ hidden_field }}
 {% endfor %}
 
-{% if form.non_field_errors %}
-  <div class="alert alert-danger" role="alert">
-    {% for error in form.non_field_errors %}
-      {{ error }}
-    {% endfor %}
-  </div>
+{% if game_form.non_field_errors %}
+<div class="alert alert-danger" role="alert">
+  {% for error in game_form.non_field_errors %}
+  {{ error }}
+  {% endfor %}
+</div>
 {% endif %}
 
-{% regroup form.visible_fields by field.group as field_groups %}
+{% for field in game_form %}
+<div class="form-group">
+  {{ field.label_tag }}
 
-{% for field_group in field_groups %}
-  {% if forloop.last %}
-  <hr />
-  {% endif %}
-  {% for field in field_group.list %}
-    {% if not field_group.grouper %}
-      <div class="form-group">
-        <label>{{ field.label_tag }}</label>
-
-        {% if form.is_bound %}
-          {% if field.errors %}
-            {% render_field field class="form-control is-invalid" %}
-            {% for error in field.errors %}
-              <div class="invalid-feedback">
-                {{ error }}
-              </div>
-            {% endfor %}
-          {% else %}
-            {% render_field field class="form-control is-valid" %}
-          {% endif %}
-        {% else %}
-          {% render_field field class="form-control" %}
-        {% endif %}
-
-        {% if field.help_text %}
-          <small class="form-text text-muted">{{ field.help_text }}</small>
-        {% endif %}
-      </div>
-    {% endif %}
-
-    {% if field_group.grouper == 'snake' %}
-      {% if forloop.counter0|divisibleby:2 %}
-        <div class="form-row">
-      {% endif %}
-      <div class="form-group col-md-6">
-        <label>{{ field.label_tag }}</label>
-
-        {% if form.is_bound %}
-          {% if field.errors %}
-            {% render_field field class="form-control is-invalid" %}
-            {% for error in field.errors %}
-              <div class="invalid-feedback">
-                {{ error }}
-              </div>
-            {% endfor %}
-          {% else %}
-            {% render_field field class="form-control is-valid" %}
-          {% endif %}
-        {% else %}
-          {% render_field field class="form-control" %}
-        {% endif %}
-
-        {% if field.help_text %}
-        <small class="form-text text-muted">{{ field.help_text }}</small>
-        {% endif %}
-      </div>
-      {% if forloop.counter|divisibleby:2 %}
+  {% if game_form.is_bound %}
+    {% if field.errors %}
+      {% render_field field class="form-control is-invalid" %}
+      {% for error in field.errors %}
+        <div class="invalid-feedback">
+          {{ error }}
         </div>
-      {% endif %}
+      {% endfor %}
+    {% else %}
+      {% render_field field class="form-control is-valid" %}
     {% endif %}
-  {% endfor %}
+  {% else %}
+    {% render_field field class="form-control" %}
+  {% endif %}
+
+  {% if field.help_text %}
+    <small class="form-text text-muted">{{ field.help_text }}</small>
+  {% endif %}
+</div>
 {% endfor %}
+
+<hr />
+
+<div id="snake_form_rows">
+  <datalist id="user-snakes">
+    {% for snake in snakes %}
+      <option value="{{snake.url}}">
+    {% endfor %}
+  </datalist>
+
+  <div class="form-group d-flex justify-content-end js-snake-add"></div>
+
+  {{ snake_formset.management_form }}
+
+  {% for form in snake_formset %}
+    <div class="card form-group js-snake-formset">
+      <div class="card-body form-row">
+        <div class="col-10">
+          {% for field in form %}
+            <div class="form-group row">
+              <label for="{{ field.id_for_label }}" class="col-4 col-form-label">
+                {{ field.label }}
+              </label>
+
+              <div class="col-8">
+                {% if form.is_bound %}
+                  {% if field.errors %}
+                    {% if 'url' in field.html_name %}
+                      {% render_field field list="user-snakes" class="form-control is-invalid" %}
+                    {% else %}
+                      {% render_field field class="form-control is-invalid" %}
+                    {% endif %}
+                    {% for error in field.errors %}
+                      <div class="invalid-feedback">
+                        {{ error }}
+                      </div>
+                    {% endfor %}
+                  {% else %}
+                    {% if 'url' in field.html_name %}
+                      {% render_field field list="user-snakes" class="form-control is-valid" %}
+                    {% else %}
+                      {% render_field field class="form-control is-valid" %}
+                    {% endif %}
+                  {% endif %}
+                {% else %}
+                  {% if 'url' in field.html_name %}
+                    {% render_field field list="user-snakes" class="form-control" %}
+                  {% else %}
+                    {% render_field field class="form-control" %}
+                  {% endif %}
+                {% endif %}
+
+                {% if field.help_text %}
+                <small class="form-text text-muted">{{ field.help_text }}</small>
+                {% endif %}
+              </div>
+            </div>
+          {% endfor %}
+        </div>
+        <div class="col-2 d-flex align-items-center justify-content-end">
+          <div class="form-group js-snake-remove"></div>
+        </div>
+      </div>
+    </div>
+  {% endfor %}
+</div>

--- a/play/templates/base.html
+++ b/play/templates/base.html
@@ -14,6 +14,7 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.3/umd/popper.min.js" integrity="sha384-ZMP7rVo3mIykV+2+9J3UJ46jBk0WLaUAdn689aCwoqbBJiSnjAK/l8WvCWPIPm49" crossorigin="anonymous"></script>
   <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.1.2/js/bootstrap.min.js" integrity="sha384-o+RDsa0aLu++PJvFqy8fFScvbHFLtbvScb8AjopnFD+iEQ7wo/CG0xlczd+2O/em" crossorigin="anonymous"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/domready/1.0.8/ready.min.js" integrity="sha256-z7v8HmIeZylwLaPn0X0Ym8dFyV0vkFVe4BkVW/iuwmQ=" crossorigin="anonymous"></script>
+  <script src="{% static 'jquery.formset.js' %}"></script>
   {% block extra_js %}{% endblock %}
 
 </head>
@@ -44,23 +45,6 @@
   {% block content %}{% endblock %}
 </body>
 <script>
-  (function() {
-    // Pulled from the Bootstrap docs
-    // Fetchs all the forms in the document to apply custom Bootstrap validation styles to
-    // then loops over them and prevent submissions, triggering custom Bootstrap styling
-    'use strict';
-    window.addEventListener('load', function() {
-      Array.prototype.filter.call(document.forms, function(form) {
-        form.addEventListener('submit', function(event) {
-          if (form.checkValidity() === false) {
-            event.preventDefault()
-            event.stopPropagation()
-          }
-          form.classList.add('was-validated')
-        }, false)
-      })
-    }, false)
-  })();
   domready(function () {
     {% block js_dom_ready %}{% endblock %}
   })

--- a/play/templates/base.html
+++ b/play/templates/base.html
@@ -36,8 +36,8 @@
     {% endblock %}
     <div class="navbar-right">
       {% block navbar_right %}
-        <span class="navbar-text">
-          <small>Logged in as:</small> <strong>{{ user.username }}</strong>
+        <span class="navbar-text small">
+          Logged in as: <strong>{{ user.username }}</strong> | <a href="/logout">Logout</a>
         </span>
       {% endblock %}
     </div>


### PR DESCRIPTION
A couple things to note here:
- I am using the `/snakes/` page data in a datalist element for the URL field on the `/games/new/` page for snake URLs. This isn't a great way, but its easier than bringing in a 3rd-partty script for similar functionality
- There's a max of 10 snakes, and a minimum of 1, validation for each field

![game](https://user-images.githubusercontent.com/1509352/43563945-3a23d500-95d9-11e8-8d56-dce128cfc295.gif)

I could probably write some tests for these functions as well