### PR TITLE
Display message when snake is being validated

### DIFF
--- a/play/apps/snake/templates/snakes/index.html
+++ b/play/apps/snake/templates/snakes/index.html
@@ -102,7 +102,7 @@ $(document).on('click', '.popover .close', function () {
   $(this).parents('.popover').popover('dispose')
 })
 
-function validateSnake(snakeUrl, callback){
+function validateSnake(snakeUrl, button, callback){
   var engineUrl = window.__battlesnake.settings.ENGINE_URL
   $.ajax({
     async: true,
@@ -112,7 +112,7 @@ function validateSnake(snakeUrl, callback){
   .done(callback)
   .fail(function(xhr, message, error) {
     console.error(`Snake validation resposne failed: ${message} ${error}`)
-    changeInfoButtonState('btn-danger')
+    changeInfoButtonState(button, 'btn-danger')
     snakeStatuses[snakeUrl] = status('Could not contact engine to validate snake', 'danger')
   })
 }
@@ -140,19 +140,18 @@ function status(message, type) {
   return `<div class="alert alert-${type} text-center">${message}</div>`
 }
 
-function changeInfoButtonState(state) {
-  const $elem = $('.js-show-snake-status')
-  $elem.removeClass('btn-success')
-  $elem.removeClass('btn-light')
-  $elem.removeClass('btn-danger')
-  $elem.addClass(state)
+function changeInfoButtonState(button, state) {
+  button.removeClass('btn-success')
+  button.removeClass('btn-light')
+  button.removeClass('btn-danger')
+  button.addClass(state)
 }
 
 function updateAllSnakeStatusLabels() {
   $('.js-show-snake-status').each(function(index,currentSnake){
     var $elem = $(this)
     var snakeUrl = $elem.data('snake-url')
-    validateSnake(snakeUrl, function(data){
+    validateSnake(snakeUrl, $elem, function(data){
       var hasErrors = false
 
       var scoreTotal = 0
@@ -168,7 +167,7 @@ function updateAllSnakeStatusLabels() {
           'Status: <span class="badge badge-sm ' + (item.statusCode !== 200 ? 'badge-danger' : 'badge-success') + '">' + item.statusCode + '</span><br />' +
           'Checks: <span class="badge badge-success badge-sm">' + item.score.checksPassed + ' passed</span>' + (item.score.checksFailed !== 0 ? ' / <span class="badge badge-danger badge-sm">' + item.score.checksFailed + ' failed</span>' : '') + '<br />' +
           'Message: ' + item.Message +
-          '</p>' 
+          '</p>'
 
         if (item.Errors.length) {
           hasErrors = true
@@ -186,9 +185,9 @@ function updateAllSnakeStatusLabels() {
       }
 
       if (scorePassedTotal < scoreTotal) {
-        changeInfoButtonState('btn-danger')
+        changeInfoButtonState($elem, 'btn-danger')
       } else {
-        changeInfoButtonState('btn-success')
+        changeInfoButtonState($elem, 'btn-success')
       }
 
       snakeStatuses[snakeUrl] = html

--- a/play/apps/snake/templates/snakes/index.html
+++ b/play/apps/snake/templates/snakes/index.html
@@ -108,8 +108,13 @@ function validateSnake(snakeUrl, callback){
     async: true,
     dataType: 'json',
     url: engineUrl + '/validateSnake?url=' + snakeUrl,
-    success: callback
-  });
+  })
+  .done(callback)
+  .fail(function(xhr, message, error) {
+    console.error(`Snake validation resposne failed: ${message} ${error}`)
+    changeInfoButtonState('btn-danger')
+    snakeStatuses[snakeUrl] = status('Could not contact engine to validate snake', 'danger')
+  })
 }
 
 var snakeStatuses = []
@@ -126,10 +131,22 @@ $('.js-show-snake-status').on('click', function (event) {
     trigger: 'click',
     title: 'Snake API Validation <button type="button" class="close" aria-label="Close" style="line-height: .6;"><span aria-hidden="true">&times;</span></button>',
     html: true,
-    content: snakeStatuses[snakeUrl],
+    content: snakeStatuses[snakeUrl] || status('Snake is currently being validated ...', 'info')
   })
   $elem.popover('show')
 })
+
+function status(message, type) {
+  return `<div class="alert alert-${type} text-center">${message}</div>`
+}
+
+function changeInfoButtonState(state) {
+  const $elem = $('.js-show-snake-status')
+  $elem.removeClass('btn-success')
+  $elem.removeClass('btn-light')
+  $elem.removeClass('btn-danger')
+  $elem.addClass(state)
+}
 
 function updateAllSnakeStatusLabels() {
   $('.js-show-snake-status').each(function(index,currentSnake){
@@ -165,17 +182,13 @@ function updateAllSnakeStatusLabels() {
       }
 
       if (!hasErrors) {
-        html = '<div class="alert alert-success text-center">No errors!</div>' + html
+        html = status('No errors!', 'success') + html
       }
 
       if (scorePassedTotal < scoreTotal) {
-        $elem.removeClass('btn-success')
-        $elem.removeClass('btn-light')
-        $elem.addClass('btn-danger')
+        changeInfoButtonState('btn-danger')
       } else {
-        $elem.removeClass('btn-light')
-        $elem.removeClass('btn-danger')
-        $elem.addClass('btn-success')
+        changeInfoButtonState('btn-success')
       }
 
       snakeStatuses[snakeUrl] = html
@@ -186,4 +199,3 @@ updateAllSnakeStatusLabels();
 setInterval(updateAllSnakeStatusLabels, 5000);
 
 {% endblock %}
-


### PR DESCRIPTION
Prior to this PR, clicking on the Snake API Validation Info button while the snake is being validated produced an error with the button not responding at all.  

![error](https://user-images.githubusercontent.com/7284672/51797123-ea481a80-21b2-11e9-8159-1f79a0b7ec87.png)

This can occur for a while if you are using the free Heroku tiers which go to sleep.

This PR adds better user feedback to this button, showing a `Snake is currently being validated ...` message while the validation API call is still occurring.  If the snake API validation call fails, it will also display a message.